### PR TITLE
refactor: header -> preamble

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -24,7 +24,7 @@ repository. Note that the information may be out of sync with released packages.
 | `missing_runtime_block`   | `v1::W005` | Completeness | [`wdl-grammar`][wdl-grammar-lints] |
 | `snake_case`              | `v1::W006` | Naming       | [`wdl-grammar`][wdl-grammar-lints] |
 | `newline_eof`             | `v1::W007` | Spacing      | [`wdl-grammar`][wdl-grammar-lints] |
-| `header_comment`          | `v1::W010` | Style        | [`wdl-grammar`][wdl-grammar-lints] |
+| `preamble_comment`        | `v1::W010` | Style        | [`wdl-grammar`][wdl-grammar-lints] |
 
 [wdl-ast-lints]: https://docs.rs/wdl-ast/latest/wdl_ast/v1/index.html#lint-rules
 [wdl-ast-validation]: https://docs.rs/wdl-ast/latest/wdl_ast/v1/index.html#validation-rules

--- a/wdl-grammar/CHANGELOG.md
+++ b/wdl-grammar/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Adds the `snake_case` rule that ensures all tasks, workflows, and variables
   are snakecase (#13, contributed by @simojoe).
 * Adds the `newline_eof` rule for tasks (#18, contributed by @simojoe).
-* Adds the `header_comment` rule for header comment formatting (contributed by 
+* Adds the `preamble_comment` rule for preamble comment formatting (contributed by 
   @simojoe).
 
 ## 0.2.0 - 12-17-2023

--- a/wdl-grammar/src/v1.rs
+++ b/wdl-grammar/src/v1.rs
@@ -23,7 +23,7 @@
 //! | `missing_runtime_block` | `v1::W005` | Completeness | [Link](lint::MissingRuntimeBlock) |
 //! | `snake_case`            | `v1::W006` | Naming       | [Link](lint::SnakeCase)           |
 //! | `newline_eof`           | `v1::W007` | Spacing      | [Link](lint::NewlineEOF)          |
-//! | `header_comment`        | `v1::W010` | Style        | [Link](lint::HeaderComment)       |
+//! | `preamble_comment`      | `v1::W010` | Style        | [Link](lint::PreambleComment)     |
 
 use pest::iterators::Pair;
 use pest::Parser as _;

--- a/wdl-grammar/src/v1/lint.rs
+++ b/wdl-grammar/src/v1/lint.rs
@@ -2,7 +2,7 @@
 
 use pest::iterators::Pair;
 
-mod header_comment;
+mod preamble_comment;
 mod missing_runtime_block;
 mod mixed_indentation;
 mod newline_eof;
@@ -10,7 +10,7 @@ mod no_curly_commands;
 mod snake_case;
 mod whitespace;
 
-pub use header_comment::HeaderComment;
+pub use preamble_comment::PreambleComment;
 pub use missing_runtime_block::MissingRuntimeBlock;
 pub use mixed_indentation::MixedIndentation;
 pub use newline_eof::NewlineEOF;
@@ -34,6 +34,6 @@ pub fn rules<'a>() -> Vec<Box<dyn wdl_core::concern::lint::Rule<&'a Pair<'a, cra
         // v1::W007
         Box::new(NewlineEOF),
         // v1::W010
-        Box::new(HeaderComment),
+        Box::new(PreambleComment),
     ]
 }

--- a/wdl-grammar/src/v1/lint/preamble_comment.rs
+++ b/wdl-grammar/src/v1/lint/preamble_comment.rs
@@ -1,4 +1,4 @@
-//! Header comments are full line comments starting with a double pound sign
+//! Preamble comments are full line comments starting with a double pound sign
 
 use std::collections::VecDeque;
 
@@ -14,12 +14,12 @@ use wdl_core::Version;
 
 use crate::v1;
 
-/// Detects header comments declaration
+/// Detects preamble comments declaration
 #[derive(Debug)]
-pub struct HeaderComment;
+pub struct PreambleComment;
 
-impl<'a> HeaderComment {
-    /// Creates a warning for header comments without double pound sign
+impl<'a> PreambleComment {
+    /// Creates a warning for preamble comments without double pound sign
     fn missing_double_pound_sign(&self, location: Location) -> lint::Warning
     where
         Self: Rule<&'a Pair<'a, v1::Rule>>,
@@ -28,9 +28,9 @@ impl<'a> HeaderComment {
             .code(self.code())
             .level(lint::Level::Low)
             .group(self.group())
-            .subject("header comments without a double pound sign")
+            .subject("preamble comments without a double pound sign")
             .body(
-                "Header comments are full line comments before the version declaration and they \
+                "Preamble comments are full line comments before the version declaration and they \
                  start with a double pound sign.",
             )
             .push_location(location)
@@ -39,8 +39,8 @@ impl<'a> HeaderComment {
             .unwrap()
     }
 
-    /// Creates a warning for header comments after version declaration
-    fn header_comment_after_version(&self, location: Location) -> lint::Warning
+    /// Creates a warning for preamble comments after version declaration
+    fn preamble_comment_after_version(&self, location: Location) -> lint::Warning
     where
         Self: Rule<&'a Pair<'a, v1::Rule>>,
     {
@@ -48,7 +48,7 @@ impl<'a> HeaderComment {
             .code(self.code())
             .level(lint::Level::Low)
             .group(self.group())
-            .subject("double pound sign are reserved for header comment")
+            .subject("double pound sign are reserved for preamble comment")
             .body(
                 "Only full line comment before version declaration should start with a double \
                  pound sign.",
@@ -60,7 +60,7 @@ impl<'a> HeaderComment {
     }
 }
 
-impl<'a> Rule<&Pair<'a, v1::Rule>> for HeaderComment {
+impl<'a> Rule<&Pair<'a, v1::Rule>> for PreambleComment {
     fn code(&self) -> Code {
         // SAFETY: this manually crafted to unwrap successfully every time.
         Code::try_new(code::Kind::Warning, Version::V1, 10).unwrap()
@@ -73,26 +73,26 @@ impl<'a> Rule<&Pair<'a, v1::Rule>> for HeaderComment {
     fn check(&self, tree: &Pair<'a, v1::Rule>) -> lint::Result {
         let mut warnings = VecDeque::new();
 
-        let mut is_header = true;
+        let mut is_preamble = true;
 
         for node in tree.clone().into_inner().flatten() {
             match node.as_rule() {
                 v1::Rule::version => {
-                    is_header = false;
+                    is_preamble = false;
                 }
                 v1::Rule::COMMENT => {
                     // Catches missing double pound sign
-                    if is_header & !node.as_str().starts_with("##") {
+                    if is_preamble & !node.as_str().starts_with("##") {
                         let location =
                             Location::try_from(node.as_span()).map_err(lint::Error::Location)?;
                         warnings.push_back(self.missing_double_pound_sign(location));
                     }
 
-                    // Catches header comment after version declaration
-                    if !is_header & node.as_str().starts_with("##") {
+                    // Catches preamble comment after version declaration
+                    if !is_preamble & node.as_str().starts_with("##") {
                         let location =
                             Location::try_from(node.as_span()).map_err(lint::Error::Location)?;
-                        warnings.push_back(self.header_comment_after_version(location));
+                        warnings.push_back(self.preamble_comment_after_version(location));
                     }
                 }
                 _ => {}
@@ -120,7 +120,7 @@ mod tests {
     use crate::v1::Rule;
 
     #[test]
-    fn it_catches_badly_formatted_header_comment() -> Result<(), Box<dyn std::error::Error>> {
+    fn it_catches_badly_formatted_preamble_comment() -> Result<(), Box<dyn std::error::Error>> {
         let tree = Parser::parse(
             Rule::document,
             r#"# a comment
@@ -130,17 +130,17 @@ version 1.0
         .next()
         .unwrap();
 
-        let warnings = HeaderComment.check(&tree)?.unwrap();
+        let warnings = PreambleComment.check(&tree)?.unwrap();
         assert_eq!(warnings.len(), 1);
         assert_eq!(
             warnings.first().to_string(),
-            "[v1::W010::Style/Low] header comments without a double pound sign (1:1-1:12)"
+            "[v1::W010::Style/Low] preamble comments without a double pound sign (1:1-1:12)"
         );
         Ok(())
     }
 
     #[test]
-    fn it_catches_header_comment_after_version() -> Result<(), Box<dyn std::error::Error>> {
+    fn it_catches_preamble_comment_after_version() -> Result<(), Box<dyn std::error::Error>> {
         let tree = Parser::parse(
             Rule::document,
             r#"## a comment
@@ -152,17 +152,17 @@ version 1.0
         .next()
         .unwrap();
 
-        let warnings = HeaderComment.check(&tree)?.unwrap();
+        let warnings = PreambleComment.check(&tree)?.unwrap();
         assert_eq!(warnings.len(), 1);
         assert_eq!(
             warnings.first().to_string(),
-            "[v1::W010::Style/Low] double pound sign are reserved for header comment (4:1-4:19)"
+            "[v1::W010::Style/Low] double pound sign are reserved for preamble comment (4:1-4:19)"
         );
         Ok(())
     }
 
     #[test]
-    fn it_ignores_a_properly_formatted_header_comment() -> Result<(), Box<dyn std::error::Error>> {
+    fn it_ignores_a_properly_formatted_preamble_comment() -> Result<(), Box<dyn std::error::Error>> {
         let tree = Parser::parse(
             Rule::document,
             r#"## a comment
@@ -171,7 +171,7 @@ version 1.0
         )?
         .next()
         .unwrap();
-        let warnings = HeaderComment.check(&tree)?;
+        let warnings = PreambleComment.check(&tree)?;
         assert!(warnings.is_none());
         Ok(())
     }


### PR DESCRIPTION
Refactor to rename `header` to `preamble`